### PR TITLE
update broken links in problem data examples to batched grading and interactive grading

### DIFF
--- a/docs/judge/problem_examples.md
+++ b/docs/judge/problem_examples.md
@@ -1,6 +1,6 @@
 # Problem Data Examples
 - [Standard Grading (IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/standard/aplusb) - implements [https://dmoj.ca/problem/aplusb](https://dmoj.ca/problem/aplusb)
-- [Batched Grading (IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/standard/hungry) - implements [https://dmoj.ca/problem/hungry](https://dmoj.ca/problem/hungry)
-- [Interactive Grading (conditional IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/interactive/game1) - implements [https://dmoj.ca/problem/game1](https://dmoj.ca/problem/game1)
+- [Batched Grading (IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/batched/hungry) - implements [https://dmoj.ca/problem/hungry](https://dmoj.ca/problem/hungry)
+- [Interactive Grading (conditional IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/interactive/seed2) - implements [https://dmoj.ca/problem/game1](https://dmoj.ca/problem/seed2)
 - [Signature Grading (IOI-style)](https://github.com/DMOJ/docs/tree/master/problem_examples/signature/siggrade) - implements [https://dmoj.ca/problem/siggrade](https://dmoj.ca/problem/siggrade)
 - [Generating IO Data on the Fly (large testcase generation)](https://github.com/DMOJ/docs/tree/master/problem_examples/generator/ds3) - implements [https://dmoj.ca/problem/ds3](https://dmoj.ca/problem/ds3)

--- a/docs/judge/problem_examples.md
+++ b/docs/judge/problem_examples.md
@@ -1,6 +1,6 @@
 # Problem Data Examples
 - [Standard Grading (IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/standard/aplusb) - implements [https://dmoj.ca/problem/aplusb](https://dmoj.ca/problem/aplusb)
 - [Batched Grading (IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/batched/hungry) - implements [https://dmoj.ca/problem/hungry](https://dmoj.ca/problem/hungry)
-- [Interactive Grading (conditional IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/interactive/seed2) - implements [https://dmoj.ca/problem/game1](https://dmoj.ca/problem/seed2)
+- [Interactive Grading (conditional IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/interactive/seed2) - implements [https://dmoj.ca/problem/seed2](https://dmoj.ca/problem/seed2)
 - [Signature Grading (IOI-style)](https://github.com/DMOJ/docs/tree/master/problem_examples/signature/siggrade) - implements [https://dmoj.ca/problem/siggrade](https://dmoj.ca/problem/siggrade)
 - [Generating IO Data on the Fly (large testcase generation)](https://github.com/DMOJ/docs/tree/master/problem_examples/generator/ds3) - implements [https://dmoj.ca/problem/ds3](https://dmoj.ca/problem/ds3)


### PR DESCRIPTION
The two links to the `hungry` and the `game` examples are currently broken. This pull request resolves those links to point to the examples in the repository (and consequently updates the game1 problem reference to seed2).

This pull request does not resolve the 404 error with `siggrade`, which is currently not publicly visible.