### PR TITLE
Update site.conf

### DIFF
--- a/sample_files/site.conf
+++ b/sample_files/site.conf
@@ -1,5 +1,5 @@
 [program:site]
-command=<path to uwsgi you just installed> --ini uwsgi.ini
+command=<path to uwsgi you just installed> --ini <path to uwsgi.ini you created>
 directory=<path to site>
 stopsignal=QUIT
 stdout_logfile=/tmp/site.stdout.log


### PR DESCRIPTION
the full path to uwsgi.ini needs to be specified, otherwise you will get

    ealpath() of uwsgi.ini failed: No such file or directory [core/utils.c line 3651]