### PR TITLE
"ruby-sass" -> "sass" on npm

### DIFF
--- a/docs/site/installation.md
+++ b/docs/site/installation.md
@@ -1,12 +1,12 @@
 ## Installing the prerequisites
 
 ```
-$ apt install git gcc g++ make python-dev libxml2-dev libxslt1-dev zlib1g-dev ruby-sass gettext curl
+$ apt install git gcc g++ make python-dev libxml2-dev libxslt1-dev zlib1g-dev gettext curl
 $ wget -q --no-check-certificate -O- https://bootstrap.pypa.io/get-pip.py | sudo python
 $ pip install virtualenv
 $ wget -O- https://deb.nodesource.com/setup_8.x | sudo -E bash -
 $ apt install nodejs
-$ npm install -g pleeease-cli
+$ npm install -g sass pleeease-cli
 ```
 
 ## Creating the database


### PR DESCRIPTION
`ruby-sass` is [deprecated](https://sass-lang.com/ruby-sass). Since we use npm tools, using the npm version of sass would be convenient and up-to-date.