### PR TITLE
Change `py` to `python` in pdf generation code tag

### DIFF
--- a/docs/site/pdf_generation.md
+++ b/docs/site/pdf_generation.md
@@ -42,7 +42,7 @@ $ rm chromedriver_linux64.zip chromedriver
 ## Configuration
 Configuring DMOJ to generate PDFs with Selenium can be done by adding the following lines to your `local_settings.py`.
 
-```py
+```python
 # Enable Selenium PDF generation
 USE_SELENIUM = True
 # Optional paths to Chromium and ChromeDriver


### PR DESCRIPTION
All other documentation uses
```
```python
```
instead of
```
```py
```