### PR TITLE
Update site repository tag to latest version

### DIFF
--- a/docs/site/installation.md
+++ b/docs/site/installation.md
@@ -44,12 +44,12 @@ You should see `(dmojsite)` prepended to your shell. Henceforth, `(dmojsite)` co
 ?> The `virtualenv` will help keep the modules needed separate from the system package manager, and save you many headaches when updating. Read more about `virtualenv`s [here](#).
 
 
-Now, fetch the site source code. If you plan to install a judge [from PyPI](https://pypi.org/project/dmoj/), check out a matching version of the site repository. For example, for judge v1.4.0:
+Now, fetch the site source code. If you plan to install a judge [from PyPI](https://pypi.org/project/dmoj/), check out a matching version of the site repository. For example, for judge v2.1.0:
 
 ```shell-session
 (dmojsite) $ git clone https://github.com/DMOJ/site.git
 (dmojsite) $ cd site
-(dmojsite) $ git checkout v1.4.0  # only if planning to install a judge from PyPI, otherwise skip this step
+(dmojsite) $ git checkout v2.1.0  # only if planning to install a judge from PyPI, otherwise skip this step
 (dmojsite) $ git submodule init
 (dmojsite) $ git submodule update
 ```


### PR DESCRIPTION
There is code in v1.4.0 that no longer works on the latest version of Python (3.8). Notably, `time.clock()` was deprecated in Python 3.3 and removed in Python 3.8. This could lead to cryptic errors for the user.