### PR TITLE
Bump up header tags so docsify properly renders sidebar subsections

### DIFF
--- a/docs/site/contest_formats.md
+++ b/docs/site/contest_formats.md
@@ -1,8 +1,8 @@
-## Contest Formats
+# Contest Formats
 
 The DMOJ ships with 4 contest formats by default: Default, Codechef IOI Ranklist (henceforth shortened to simply IOI), ECOO, and AtCoder.
 
-### Default Contest Format
+## Default Contest Format
 
 The `Default` contest format is what all contests ran on pre-April 23, 2019.
 
@@ -12,7 +12,7 @@ Note that *any* submission will increase time penalty, not just score-changing s
 
 There are no additional options that can be configured for this contest format.
 
-### IOI Contest Format
+## IOI Contest Format
 
 The `IOI` contest format emulates the scoring used by Codechef's IOI Ranklist.
 
@@ -20,7 +20,7 @@ The score is equal to the sum of the maximum scores on each problem, and by defa
 
 The `cumtime` option can be set to `true` within the JSON configuration. This will break ties by summing the submissions times of the most recent total score-changing submissions.
 
-### ECOO Contest Format
+## ECOO Contest Format
 
 The `ECOO` contest format is based on the scoring system used by the ECOO contest.
 
@@ -35,7 +35,7 @@ The field is in minutes, and for each such interval of time before the contest e
 Note that specifying `0` will disable this bonus.  
 For example, say a submission with a score of `50/100` is submitted 23 minutes before the contest ends. $\left\lfloor\frac{23}{5}\right\rfloor = 4$, so 4 bonus points are awarded, giving a total score of $50 + 4 = 54$ for that problem.
 
-### AtCoder Contest Format
+## AtCoder Contest Format
 
 The `AtCoder` contest format is based on the contest format used by AtCoder. As such, your score equals the sum of your highest-scoring submission on each problem, and ties are broken based on the time of your last score-changing submission plus your penalty.
 

--- a/docs/site/permission_system.md
+++ b/docs/site/permission_system.md
@@ -1,8 +1,8 @@
-## Permission System
+# Permission System
 
 The DMOJ's permission system is very extensive and allows fine-tuning a user's permissions. Here, we will document which permissions are required to perform certain tasks on the site. Any undocumented models means that they follow Django's default permission system of (`can_add_<model>`, `can_change_<model>`, `can_delete_<model>`, and `can_view_<model>`).
 
-### Blog Posts
+## Blog Posts
 Blog posts follow Django's default permission system.
 
 #### `edit_all_post` (Edit all posts)
@@ -10,13 +10,13 @@ Blog posts follow Django's default permission system.
 
 The user can edit all blog posts.
 
-### Comments
+## Comments
 Comments and comment locks follow Django's default permission system.
 
 #### `override_comment_lock` (Override comment lock)
 The user can post comments on pages which are comment locked.
 
-### Contests
+## Contests
 Contest participations, contest problems, contest submissions, and contest tags follow Django's default permission system.
 
 #### `see_private_contest` (See private contests)
@@ -54,7 +54,7 @@ The user can edit the `is_visible` field on the contest admin page.
 #### `contest_problem_label` (Edit contest problem label script)
 The user can edit the contest problem label script on the contest admin page.
 
-### Organizations
+## Organizations
 Organizations follow Django's default permission system.
 
 #### `organization_admin` (Administer organizations)
@@ -65,7 +65,7 @@ The user can edit `registrant`, `admins`, `is_open`, `slots` fields on the admin
 
 The user can edit all organizations.
 
-### Problems
+## Problems
 
 #### `see_organization_problem` (See organization-private problems)
 The user can see organization-private (but public) problems.
@@ -78,7 +78,7 @@ The user can see all problems. However, they will *not* be able to edit problems
 #### `edit_own_problem` (Edit own problems)
 The user can edit problems on the admin site, but only if they are explicitly set as author or curator. They will also be able to view submission source code for these problems.
 
-### `edit_public_problem` (Edit public problems)
+#### `edit_public_problem` (Edit public problems)
 **Prerequisite perrmisions: `edit_own_problem`**
 
 The user can edit problems on the admin site, but only if the problem is public. They will also be able to view submission source code for these problems.
@@ -105,13 +105,13 @@ Problem solutions follow Django's default permission system.
 #### `see_private_solution` (See hidden solutions)
 The user can see all problem solutions for problems they can access, regardless of if the solution is public or not.
 
-### Profile
+## Profile
 Profiles follow Django's default permission system.    
 
 #### `totp` (Edit TOTP settings)
 The user can edit TOTP-related fields.
 
-### Submissions
+## Submissions
 
 Submission visibility and editability are determined by problem permissions. 
 If the user can edit the problem, they can also edit related submissions.

--- a/docs/site/recaptcha.md
+++ b/docs/site/recaptcha.md
@@ -1,4 +1,4 @@
-## Installing reCAPTCHA Spam Registration Prevention
+# Installing reCAPTCHA Spam Registration Prevention
 
 If you run DMOJ for any prolonged period of time, eventually spambots will begin registering in large numbers.
 


### PR DESCRIPTION
For example, right now:
![image](https://user-images.githubusercontent.com/29607503/86603742-66cb5500-bf72-11ea-96d4-33d6236ee484.png)

By bumping up the header tags, the different contest formats should show up on the sidebar.