### PR TITLE
Fix license formatting typo

### DIFF
--- a/docs/about/LICENSE.md
+++ b/docs/about/LICENSE.md
@@ -99,7 +99,7 @@ work under this License, and how to view a copy of this License.  If
 the interface presents a list of user commands or options, such as a
 menu, a prominent item in the list meets this criterion.
 
-###1. Source Code.
+### 1. Source Code.
 
 The "source code" for a work means the preferred form of the work
 for making modifications to it.  "Object code" means any non-source


### PR DESCRIPTION
The header of the "Source Code" section of the license in the docs is missing a space

![image](https://user-images.githubusercontent.com/25178974/112502731-b223ce80-8d60-11eb-9f56-b2cc74aaf060.png)
