### PR TITLE
Update remaining grader examples

### DIFF
--- a/docs/problem_format/custom_graders.md
+++ b/docs/problem_format/custom_graders.md
@@ -1,6 +1,6 @@
 # Custom Graders
 
-# Custom Grader Behaviour - `grader`
+## Custom Grader Behaviour - `grader`
 
 An `init.yml` object can contain a top-level `custom_judge` node, which contains a path to a Python file to be executed as a grader for the problem. The grader has access to the archive specified in `archive`.
 
@@ -12,7 +12,7 @@ class Grader(BaseGrader):
     pass
 ```
 
-## Parameters
+### Parameters
 
 `case` is a `TestCase` object.
 
@@ -21,7 +21,7 @@ class Grader(BaseGrader):
 - `case.output_data()` is a buffer containing the contents of the `out` file specified for the current case in `init.yml`. May be `b''`, if no case output file was specified.
 - `case.points` is an integer, the max points that can be awarded for the current test case.
 
-## Returns
+### Returns
 
 A `Result` object (`from dmoj.result import Result`). Some notable fields include:
 
@@ -29,6 +29,8 @@ A `Result` object (`from dmoj.result import Result`). Some notable fields includ
 - `proc_output`: contains the string that will be displayed in the partial output pane. However, if `result_flag` is `Result.AC`, then the partial output pane will not be shown.
 - `feedback`: contains the feedback given by the judge.
 - `extended_feedback`: contains any extended feedback that would not fit into the shorter `feedback` field, and is displayed as a separate pane beside the partial output on the site.
+
+### Example
 
 To illustrate, in a problem where the process must echo a line of input, an interactive approach would look like this:
 
@@ -81,7 +83,7 @@ Since we use no input or output files (our test case is hardcoded), we do not ne
 
 In this example, it's important to note the `unbuffered` node. If set to `true`, the judge will use a pseudoterminal device for a submission's input and output pipes. Since ptys are not buffered by design, setting `unbuffered` to `true` removes the need for user submissions to `flush()` their output stream to guarantee that the `grader` receives their response. **The `unbuffered` node is not exclusive to interactive grading: it may be specified regardless of judging mode.**
 
-# Interactive Grading
+## Interactive Grading
 
 Interactive grading is used for problems where users should implement an online algorithm or where the grader must generate input or compute a score based on the user's previous output.
 Using an interactive grader is similar to using a custom grader: the `custom_judge` node also needs to be set. Rewriting the previous custom judge using an interactive grader would result in:
@@ -103,7 +105,7 @@ class Grader(InteractiveGrader):
     return case_input == utf8text(interactor.readln())
 ```
 
-## Parameters
+### Parameters
 
 `case` is a `TestCase` object, and is identical to the one in the `Grader` section.
 `interactor` is an `Interactor` object.
@@ -117,28 +119,29 @@ class Grader(InteractiveGrader):
 - `interactor.writeln(val)` writes `val`, cast to a string, to the submission's standard input, followed by a newline.
 - `interactor.close()` closes the submission's `stdin` stream.
 
-## Returns
+### Returns
 
-Either a boolean or a `Result` (`from dmoj.result import Result`) object. The boolean is true if the submission should score full points, and `false` otherwise. The `Result` object is handled the same way as custom graders.
+Either a boolean or a `Result` (`from dmoj.result import Result`) object. The boolean is `True` if the submission should score full points, and `False` otherwise. The `Result` object is handled the same way as custom graders.
 
 ## Native Interactive Grading
+
 Sometimes, an interactive grader will be very computationally expensive.
 In these cases, one can use the `bridged` grader.
-To invoke the `bridged` grader, `interactive` should be a top level node that contains `files` and `lang`.
+To invoke the `bridged` grader, `interactive` should be a top-level node that contains `files`.
 `files` is either a single filename, or a list of filenames, corresponding to the interactor.
-`lang` is the language of the interactor.
 
 Optional arguments are:
 
+- `lang`: the language of the interactor. If empty, the judge will attempt to detect the language from the filename extension(s). Currently, the judge can detect `.cpp`, `.cc`, and `.c`.
 - `flags`: flags to pass to the compiler.
-- `compiler_time_limit`: the time limit allocated to compiling the interactor.
-- `preprocessing_time`: the interactor's time limit is equal to this value plus the time limit of the problem, in seconds.
+- `compiler_time_limit`: the time limit allocated to compiling the interactor. It defaults to `env['compiler_time_limit']`.
+- `preprocessing_time`: the interactor's time limit is equal to this value plus the time limit of the problem, in seconds. It defaults to 2.
 - `memory_limit`: the memory limit allocated to the interactor. It defaults to `env['generator_memory_limit']`.
-- `type`: specifies the arguments to pass the checker and how to interpret the checker's return code and output.
+- `type`: specifies the arguments to pass to the checker and how to interpret the checker's return code and output.
   - The `default` type passes the arguments in the order `input_file judge_file`. A return code of `0` is an AC, `1` is a WA, and anything else results in an internal error.
   - The `testlib` type passes the arguments in the order `input_file output_file judge_file`.
   Note that `output_file` will always be `/dev/null`, and is passed to maintain compatibility with `testlib.h`. A return code of `0` is an AC, `1` is a WA, `2` is a presentation error, `3` corresponds to an assertion failing,
-  and `7`, along with an output to `stderr` of the format `points X` for an integral ~X~ awards ~X~ points. Anything else results in an internal error.
+  and `7`, along with an output to `stderr` of the format `points X` for an integer ~X~ awards ~X~ points. Anything else results in an internal error.
   - The `coci` type passes the arguments in the order `input_file judge_file`. Its parsing of return codes is the same as the `testlib` type, but has partial format `partial X/Y`, which awards ~\frac X Y~ of the points.
   - The `peg` type exists for compatibility with the WCIPEG judge, and is not meant to be used here.
 
@@ -148,11 +151,12 @@ After the interactor prints, it is required to flush.
 To specify a correct answer, the interactor should return 0.
 To specify an incorrect answer, the interactor should return 1.
 All other return values will be considered internal errors.
-
 To override this behaviour, you can change `type` to a valid `contrib` module, such as `testlib`.
 
+### Example
 
 An example `init.yml` would be as follows:
+
 ```yaml
 unbuffered: true
 archive: seed2.zip
@@ -163,17 +167,18 @@ test_cases:
 - {in: seed2.3.in, points: 20}
 - {in: seed2.4.in, points: 20}
 - {in: seed2.5.in, points: 20}
-- ```
+```
 
 An example of interactor is as follows. Note that it is not necessary to flush,
-even if `unbuffered` is not true.
+even if `unbuffered` is false.
+
 ```cpp
 #include <cstdio>
 #include <cstdlib>
 
 inline void read(long long *i) {
-    if(scanf("%lld", i) != 1 || *i < 1 || *i > 2000000000)
-        exit(2);
+  if (scanf("%lld", i) != 1 || *i < 1 || *i > 2000000000)
+    exit(2);
 }
 
 int main(int argc, char *argv[]) {
@@ -199,39 +204,46 @@ int main(int argc, char *argv[]) {
 }
 ```
 
-# Function Signature Grading (IOI-style)
-Signature grading is used for problems where users should implement an online algorithm or interact with the grader directly without the need for traditional input and output routines. This is commonly seen in competitions such as the IOI, where all input is passed through function arguments and output is replaced with return values or directly modifying specifically allocated memory for the computed answer. Currently, C and C++ are supported for this mode. `signature_grader` should be a top-level node that contains `entry` and `header`. `entry` is a C or C++ file that contains the `main` function. It should read input from `stdin`, call the user's implemented functions specified in `header`, and write output to `stdout`. You may specify a custom `checker` to interpret the `entry`'s output. If no custom checker is specified, it will be compared to the output file using the default checker.
+## Function Signature Grading (IOI-style)
+
+Signature grading is used for problems where users should implement an online algorithm or interact with the grader directly without the need for traditional input and output routines. This is commonly seen in competitions such as the IOI, where all input is passed through function arguments and output is replaced with return values or directly modifying specifically allocated memory for the computed answer.
+
+The following languages are supported for this mode:
+
+- The C family: C, C11, Clang
+- The C++ family: C++03, C++11, C++14, C++17, C++20, Clang++
+
+`signature_grader` should be a top-level node that contains `entry` and `header`. `entry` is a C or C++ file that contains the `main` function. It should read input from `stdin`, call the user's implemented functions specified in `header`, and write output to `stdout`. You may specify a custom `checker` to interpret the `entry`'s output. If no custom checker is specified, it will be compared to the output file using the default checker.
 
 The user's submission will be automatically modified to include the file `header`, and the symbol `main` is redefined as `main_GUID` where `GUID` is a randomly generated GUID. This is so users testing their program do not have to manually remove their `main` function before submissions; it does not protect against the preprocessor directive `#undef main`.
 
 The global variables in the `entry` should be declared static to prevent name collisions. Optimally, `header` should have an include guard, in case it contains something other than function prototypes.
 
-Note that both the `entry` and the user's code will be compiled with C++14 regardless of whether C, C++, C++03, C++11, or C++14 is selected as the language. Issues that may arise from this are naming variables like `class` in a C program, which otherwise would be allowed.
+### Example
 
 An example of the `init.yml`:
 
 ```yaml
 signature_grader: {entry: handler.c, header: header.h}
 test_cases:
-- {in: siggrade.1.in, out: siggrade.1.out, point: 50}
-- {in: siggrade.2.in, out: siggrade.2.out, point: 50}
+- {in: siggrade.1.in, out: siggrade.1.out, points: 50}
+- {in: siggrade.2.in, out: siggrade.2.out, points: 50}
 ```
 
 An example of the `entry` file:
 
 ```c
 #include "header.h"
-#include <stdio.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 static int n;
 
-int main()
-{
-    scanf("%d", &n);
-    bool valid = is_valid(n); // Defined in header
-    printf(valid ? "correct" : "wrong");
-    return 0;
+int main() {
+  scanf("%d", &n);
+  bool valid = is_valid(n); // Defined in header
+  printf(valid ? "correct" : "wrong");
+  return 0;
 }
 ```
 


### PR DESCRIPTION
Major changes:

- interactive: `lang` is optional
- siggrading: compilation is in the submission's language, not in C++14