### PR TITLE
Use MathML for math

### DIFF
--- a/docs/problem_format/custom_checkers.md
+++ b/docs/problem_format/custom_checkers.md
@@ -32,8 +32,8 @@ This checker ignores all whitespace and letter case, then checks if the number o
 
 The `floats` checker is used when outputs may suffer from floating point errors.
 
-`args` can contain a key for `precision`, indicating an epsilon of ~10^{-\text{precision}}~.
-This value defaults to `6`.
+`args` can contain a key for `precision`, indicating an epsilon of <math><msup><mn>10</mn><mrow><mo>-</mo><mi>precision</mi></mrow></msup></math>.
+This value defaults to 6.
 
 Additionally, `args` can contain a key for `error_mode`. The supported values are:
 
@@ -128,8 +128,8 @@ The `bridged` checker takes the following arguments:
 - `type`: specifies the arguments to pass to the checker and how to interpret the checker's return code and output.
   - The `default` type passes the arguments in the order `input_file output_file judge_file`. A return code of `0` is an AC, `1` is a WA, and anything else results in an internal error.
   - The `testlib` type passes the arguments in the order `input_file output_file judge_file`. A return code of `0` is an AC, `1` is a WA, `2` is a presentation error, `3` corresponds to an assertion failing,
-  and `7`, along with an output to `stderr` of the format `points X` for an integer ~X~ awards ~X~ points. Anything else results in an internal error.
-  - The `coci` type behaves similarly to the `testlib` type, but has partial format `partial X/Y`, which awards ~\frac X Y~ of the points.
+  and `7`, along with an output to `stderr` of the format `points X` for an integer <math><mi>X</mi></math> awards <math><mi>X</mi></math> points. Anything else results in an internal error.
+  - The `coci` type behaves similarly to the `testlib` type, but has partial format `partial X/Y`, which awards <math><mfrac><mi>X</mi><mi>Y</mi></mfrac></math> of the points.
   - The `peg` type exists for compatibility with the WCIPEG judge.
 
 The files will be compiled and sandboxed, then executed with the arguments `input_file`, `output_file`, and `judge_file`, which are files containing input, submission output, and judge output, respectively.

--- a/docs/problem_format/custom_graders.md
+++ b/docs/problem_format/custom_graders.md
@@ -113,8 +113,8 @@ class Grader(InteractiveGrader):
 - `interactor.read()` reads all of the submission's output available.
 - `interactor.readln(strip_newline=True)` reads the next line of the submission's output. If `strip_newline` is true, the trailing newline is stripped, otherwise it is retained.
 - `interactor.readtoken(delim=None)` reads the next available token of the submission's output, as determined by `string.split(delim)`.
-- `interactor.readint(lo=float('-inf'), hi=float('inf'), delim=None)` reads the next token of the submission's output, as determined by `string.split(delim)`. Additionally, the checker will automatically generate a wrong answer verdict if either the token cannot be converted to an integer, or if it is not in the range [*lo*, *hi*].
-- `interactor.readfloat(lo=float('-inf'), hi=float('inf'), delim=None)` reads the next token of the submission's output, as determined by `string.split(delim)`. Additionally, the checker will automatically generate a wrong answer verdict if either the token cannot be converted to a float, or if it is not in the range [*lo*, *hi*].
+- `interactor.readint(lo=float('-inf'), hi=float('inf'), delim=None)` reads the next token of the submission's output, as determined by `string.split(delim)`. Additionally, the checker will automatically generate a wrong answer verdict if either the token cannot be converted to an integer, or if it is not in the range <math><mo>[</mo><mi>lo</mi><mo>,</mo><mi>hi</mi><mo>]</mo></math>.
+- `interactor.readfloat(lo=float('-inf'), hi=float('inf'), delim=None)` reads the next token of the submission's output, as determined by `string.split(delim)`. Additionally, the checker will automatically generate a wrong answer verdict if either the token cannot be converted to a float, or if it is not in the range <math><mo>[</mo><mi>lo</mi><mo>,</mo><mi>hi</mi><mo>]</mo></math>.
 - `interactor.write(val)` writes `val`, cast to a string, to the submission's standard input.
 - `interactor.writeln(val)` writes `val`, cast to a string, to the submission's standard input, followed by a newline.
 - `interactor.close()` closes the submission's `stdin` stream.
@@ -141,8 +141,8 @@ Optional arguments are:
   - The `default` type passes the arguments in the order `input_file judge_file`. A return code of `0` is an AC, `1` is a WA, and anything else results in an internal error.
   - The `testlib` type passes the arguments in the order `input_file output_file judge_file`.
   Note that `output_file` will always be `/dev/null`, and is passed to maintain compatibility with `testlib.h`. A return code of `0` is an AC, `1` is a WA, `2` is a presentation error, `3` corresponds to an assertion failing,
-  and `7`, along with an output to `stderr` of the format `points X` for an integer ~X~ awards ~X~ points. Anything else results in an internal error.
-  - The `coci` type passes the arguments in the order `input_file judge_file`. Its parsing of return codes is the same as the `testlib` type, but has partial format `partial X/Y`, which awards ~\frac X Y~ of the points.
+  and `7`, along with an output to `stderr` of the format `points X` for an integer <math><mi>X</mi></math> awards <math><mi>X</mi></math> points. Anything else results in an internal error.
+  - The `coci` type passes the arguments in the order `input_file judge_file`. Its parsing of return codes is the same as the `testlib` type, but has partial format `partial X/Y`, which awards <math><mfrac><mi>X</mi><mi>Y</mi></mfrac></math> of the points.
   - The `peg` type exists for compatibility with the WCIPEG judge, and is not meant to be used here.
 
 The interactor's standard input is connected to the submission's standard output, and vice versa.

--- a/docs/site/contest_formats.md
+++ b/docs/site/contest_formats.md
@@ -43,7 +43,7 @@ The `time_bonus` field awards a bonus for solving problems faster.
 The field is in minutes, and for each such interval of time before the contest ends, any submission with a non-zero score will have a bonus point added. This field defaults to 5.
 Note that specifying 0 will disable this bonus.
 
-For example, say a submission with a score of 50/100 is submitted 23 minutes before the contest ends. $\left\lfloor\frac{23}{5}\right\rfloor = 4$, so 4 bonus points are awarded, giving a total score of $50 + 4 = 54$ for that problem.
+For example, say a submission with a score of 50/100 is submitted 23 minutes before the contest ends. <math><mo>&lfloor;</mo><mfrac><mn>23</mn><mn>5</mn></mfrac><mo>&rfloor;</mo><mo>=</mo><mn>4</mn></math>, so 4 bonus points are awarded, giving a total score of <math><mn>50</mn><mo>+</mo><mn>4</mn><mo>=</mo><mn>54</mn></math> for that problem.
 
 ## AtCoder
 

--- a/docs/site/managing_problems.md
+++ b/docs/site/managing_problems.md
@@ -53,7 +53,7 @@ sum of the point values of the cases they got right divided by the total sum of 
 points the problem is worth.
 
 For example, if your problem is worth 100 points and has 3 cases weighted 1/2/7 points respectively, a user who gets the first
-two cases correct and then fails the last one will have a score of (1 + 2) / (1 + 2 + 7) &times; 100 = 30 points, out of 100.
+two cases correct and then fails the last one will have a score of <math><mfrac><mrow><mn>1</mn><mo>+</mo><mn>2</mn><mo>+</mo><mn>0</mn></mrow><mrow><mn>1</mn><mo>+</mo><mn>2</mn><mo>+</mo><mn>7</mn></mrow></mfrac><mo>&times;</mo><mn>100</mn><mo>=</mo><mn>30</mn></math> points, out of 100.
 
 ## Submitting to a Problem
 


### PR DESCRIPTION
Docsify uses [Marked](https://marked.js.org/demo/) as its Markdown renderer. Apparently, MathML is rendered properly.

```
<math><msup><mn>10</mn><mrow><mo>-</mo><mi>precision</mi></mrow></msup></math>
<math><mi>X</mi></math>
<math><mfrac><mi>X</mi><mi>Y</mi></mfrac></math>
<math><mo>[</mo><mi>lo</mi><mo>,</mo><mi>hi</mi><mo>]</mo></math>
<math><mo>&lfloor;</mo><mfrac><mn>23</mn><mn>5</mn></mfrac><mo>&rfloor;</mo><mo>=</mo><mn>4</mn></math>
<math><mn>50</mn><mo>+</mo><mn>4</mn><mo>=</mo><mn>54</mn></math>
<math><mfrac><mrow><mn>1</mn><mo>+</mo><mn>2</mn><mo>+</mo><mn>0</mn></mrow><mrow><mn>1</mn><mo>+</mo><mn>2</mn><mo>+</mo><mn>7</mn></mrow></mfrac><mo>&times;</mo><mn>100</mn><mo>=</mo><mn>30</mn></math>
```

Browsers that don't have MathML will display everything on one line, so `msup` and `mfrac` will look confusing.