### PR TITLE
Update site.conf

### DIFF
--- a/sample_files/site.conf
+++ b/sample_files/site.conf
@@ -1,6 +1,8 @@
 [program:site]
 command=<path to virtualenv>/bin/uwsgi --ini uwsgi.ini
 directory=<path to site>
+user=<user to run under>
+group=<user to run under>
 stopsignal=QUIT
 stdout_logfile=/tmp/site.stdout.log
 stderr_logfile=/tmp/site.stderr.log


### PR DESCRIPTION
Without user and group fields, permission denied error will be thrown (on Ubuntu 22.04 at least)