### PR TITLE
 Update supported languages list in docs to include Node.js Javascript 

### DIFF
--- a/docs/judge/supported_languages.md
+++ b/docs/judge/supported_languages.md
@@ -5,11 +5,12 @@ Ada, Assembly (x64/x86), AWK, Brain\*\*\*\*,
 C (Clang/GCC), C#, C++14 (Clang/GCC),
 C++03/11/17/20, C11, COBOL, D, Dart, F#, Forth,
 Fortran, Go, Groovy, Haskell, INTERCAL,
-Java 8/latest, Kotlin, Lean 4, Lisp, LLVM IR, Lua, NASM,
+Java 8/latest, JavaScript (Node.js and V8),
+Kotlin, Lean 4, Lisp, LLVM IR, Lua, NASM,
 NASM64, OCaml, Pascal, Perl, PHP, Pike, Prolog,
 PyPy 2/3, Python 2/3, Racket, Ruby, Rust, Scala,
 Scheme, Sed, Swift, TCL, Text, Turing,
-V8 JavaScript, Visual Basic, Zig.
+Visual Basic, Zig.
 All these languages are tested in production on the [DMOJ](https://dmoj.ca/).
 
 As it stands, some languages are used more than others in the scope of competitive programming, so some executors have

--- a/docs/site/installation.md
+++ b/docs/site/installation.md
@@ -106,6 +106,10 @@ Next, load some initial data so that your install is not entirely blank.
 (dmojsite) $ python3 manage.py loaddata navbar
 (dmojsite) $ python3 manage.py loaddata language_small
 (dmojsite) $ python3 manage.py loaddata demo
+
+# If you want more languages and are running the runtimes-tier3
+# version of the Docker image, load them with:
+(dmojsite) $ python3 manage.py loaddata language_all
 ```
 
 !>  Keep in mind that the `demo` fixture creates a superuser account with a username and password of `admin`. If your


### PR DESCRIPTION
### Motivation

Related to https://github.com/DMOJ/judge-server/pull/1143:

After enabling support in judge-server for a Node.js-based executor, we need add the language to the demo instance and the documentation

### Changes

- Add JavaScript (Node.js) to languages list
- Mention the `language_all` test data fixture for loading in the default list of all (tier3) images

### Testing

N/A: did not test