### PR TITLE
Fix signature grading sample problem in problem_examples.md

### DIFF
--- a/docs/problem_format/problem_examples.md
+++ b/docs/problem_format/problem_examples.md
@@ -7,5 +7,5 @@
 | [Custom Grading](https://github.com/DMOJ/docs/tree/master/problem_examples/grader/shortest1) | <https://dmoj.ca/problem/shortest1> |
 | [Interactive Grading (conditional IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/interactive/seed2) | <https://dmoj.ca/problem/seed2> |
 | [Native Interactive Grading (conditional IO-based)](https://github.com/DMOJ/docs/tree/master/problem_examples/interactive/seed2native) | <https://dmoj.ca/problem/seed2> |
-| [Signature Grading (IOI-style)](https://github.com/DMOJ/docs/tree/master/problem_examples/signature/siggrade) | <https://dmoj.ca/problem/siggrade> |
+| [Signature Grading (IOI-style)](https://github.com/DMOJ/docs/tree/master/problem_examples/signature/fastbit) | <https://dmoj.ca/problem/fastbit> |
 | [Generating IO Data on the Fly (large test case generation)](https://github.com/DMOJ/docs/tree/master/problem_examples/generator/ds3) | <https://dmoj.ca/problem/ds3> |


### PR DESCRIPTION
When the sample problem for signature grading got changed to fastbit from #135 the [problem_examples.md](https://github.com/DMOJ/docs/blob/master/docs/problem_format/problem_examples.md) file got left out. This PR just makes the two files consistent with each other