### PR TITLE
Update MariaDB setup

### DIFF
--- a/docs/site/installation.md
+++ b/docs/site/installation.md
@@ -24,10 +24,11 @@ $ apt install mariadb-server libmysqlclient-dev
 The next step is to set up the database itself. You should execute the commands listed below to create the necessary database and user.
 
 ```shell-session
-$ sudo mysql
-mariadb> CREATE DATABASE dmoj DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_general_ci;
-mariadb> GRANT ALL PRIVILEGES ON dmoj.* TO 'dmoj'@'localhost' IDENTIFIED BY '<mariadb user password>';
-mariadb> exit
+$ sudo mariadb
+MariaDB [(none)]> CREATE DATABASE dmoj DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_general_ci;
+MariaDB [(none)]> GRANT ALL PRIVILEGES ON dmoj.* TO 'dmoj'@'localhost' IDENTIFIED BY '<mariadb user password>';
+MariaDB [(none)]> exit
+$ mariadb-tzinfo-to-sql /usr/share/zoneinfo | sudo mariadb -u root mysql  # Add time zone data to the database. A few pages require this.
 ```
 
 ## Installing prerequisites


### PR DESCRIPTION
This warning started appearing since mariadb 11.0:

```
$ sudo mysql
mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
```

Switch from `sudo mysql` to `sudo mariadb`. This should be safe [since 10.4.6](https://mariadb.com/kb/en/mariadb-command-line-client/).

Also, add a timezone command to get rid of this timezone error in `/admin/judge/contest/`: `Database returned an invalid datetime value. Are time zone definitions for your database installed?`