### PR TITLE
problem_setting: speed up int validation

### DIFF
--- a/sample_files/problem_setting/examples/identical_checker.cpp
+++ b/sample_files/problem_setting/examples/identical_checker.cpp
@@ -75,10 +75,28 @@ std::string readToken(char min_char = 0, char max_char = 127) {
   return token;
 }
 
+bool validateInt(const std::string &token) {
+  if (token == "0") {
+    return true;
+  }
+  auto i = 0u;
+  if (i < token.size() && token[i] == '-') {
+    ++i;
+  }
+  if (i >= token.size() || token[i] < '1' || '9' < token[i]) {
+    return false;
+  }
+  for (i++; i < token.size(); i++) {
+    if (token[i] < '0' || '9' < token[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 long long readInt(long long lo, long long hi) {
-  static regex_t re = regex_helpers::compile("^(0|-?[1-9][0-9]*)$");
   std::string token = readToken();
-  assertWA(regex_helpers::match(re, token));
+  assertWA(validateInt(token));
 
   long long parsedInt;
   try {

--- a/sample_files/problem_setting/examples/standard_interactor.cpp
+++ b/sample_files/problem_setting/examples/standard_interactor.cpp
@@ -129,10 +129,28 @@ std::string readToken(char min_char = 0, char max_char = 127) {
   return token;
 }
 
+bool validateInt(const std::string &token) {
+  if (token == "0") {
+    return true;
+  }
+  auto i = 0u;
+  if (i < token.size() && token[i] == '-') {
+    ++i;
+  }
+  if (i >= token.size() || token[i] < '1' || '9' < token[i]) {
+    return false;
+  }
+  for (i++; i < token.size(); i++) {
+    if (token[i] < '0' || '9' < token[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 long long readInt(long long lo, long long hi) {
-  static regex_t re = regex_helpers::compile("^(0|-?[1-9][0-9]*)$");
   std::string token = readToken();
-  assertWA(regex_helpers::match(re, token));
+  assertWA(validateInt(token));
 
   long long parsedInt;
   try {

--- a/sample_files/problem_setting/examples/validator.cpp
+++ b/sample_files/problem_setting/examples/validator.cpp
@@ -37,10 +37,28 @@ std::string readToken(char min_char = 0, char max_char = 127) {
   return token;
 }
 
+bool validateInt(const std::string &token) {
+  if (token == "0") {
+    return true;
+  }
+  auto i = 0u;
+  if (i < token.size() && token[i] == '-') {
+    ++i;
+  }
+  if (i >= token.size() || token[i] < '1' || '9' < token[i]) {
+    return false;
+  }
+  for (i++; i < token.size(); i++) {
+    if (token[i] < '0' || '9' < token[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 long long readInt(long long lo, long long hi) {
-  static regex_t re = regex_helpers::compile("^(0|-?[1-9][0-9]*)$");
   std::string token = readToken();
-  assert(regex_helpers::match(re, token));
+  assert(validateInt(token));
 
   long long parsedInt = stoll(token); // May throw.
   assert(lo <= parsedInt && parsedInt <= hi);

--- a/sample_files/problem_setting/identical_checker_interactor.cpp
+++ b/sample_files/problem_setting/identical_checker_interactor.cpp
@@ -87,10 +87,28 @@ std::string readLine(char min_char = 0, char max_char = 127) {
   return line;
 }
 
+bool validateInt(const std::string &token) {
+  if (token == "0") {
+    return true;
+  }
+  auto i = 0u;
+  if (i < token.size() && token[i] == '-') {
+    ++i;
+  }
+  if (i >= token.size() || token[i] < '1' || '9' < token[i]) {
+    return false;
+  }
+  for (i++; i < token.size(); i++) {
+    if (token[i] < '0' || '9' < token[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 long long readInt(long long lo, long long hi) {
-  static regex_t re = regex_helpers::compile("^(0|-?[1-9][0-9]*)$");
   std::string token = readToken();
-  assertWA(regex_helpers::match(re, token));
+  assertWA(validateInt(token));
 
   long long parsedInt;
   try {

--- a/sample_files/problem_setting/standard_checker_interactor.cpp
+++ b/sample_files/problem_setting/standard_checker_interactor.cpp
@@ -130,10 +130,28 @@ std::string readToken(char min_char = 0, char max_char = 127) {
   return token;
 }
 
+bool validateInt(const std::string &token) {
+  if (token == "0") {
+    return true;
+  }
+  auto i = 0u;
+  if (i < token.size() && token[i] == '-') {
+    ++i;
+  }
+  if (i >= token.size() || token[i] < '1' || '9' < token[i]) {
+    return false;
+  }
+  for (i++; i < token.size(); i++) {
+    if (token[i] < '0' || '9' < token[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 long long readInt(long long lo, long long hi) {
-  static regex_t re = regex_helpers::compile("^(0|-?[1-9][0-9]*)$");
   std::string token = readToken();
-  assertWA(regex_helpers::match(re, token));
+  assertWA(validateInt(token));
 
   long long parsedInt;
   try {

--- a/sample_files/problem_setting/validator.cpp
+++ b/sample_files/problem_setting/validator.cpp
@@ -52,10 +52,28 @@ std::string readLine(char min_char = 0, char max_char = 127) {
   return line;
 }
 
+bool validateInt(const std::string &token) {
+  if (token == "0") {
+    return true;
+  }
+  auto i = 0u;
+  if (i < token.size() && token[i] == '-') {
+    ++i;
+  }
+  if (i >= token.size() || token[i] < '1' || '9' < token[i]) {
+    return false;
+  }
+  for (i++; i < token.size(); i++) {
+    if (token[i] < '0' || '9' < token[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 long long readInt(long long lo, long long hi) {
-  static regex_t re = regex_helpers::compile("^(0|-?[1-9][0-9]*)$");
   std::string token = readToken();
-  assert(regex_helpers::match(re, token));
+  assert(validateInt(token));
 
   long long parsedInt = stoll(token); // May throw.
   assert(lo <= parsedInt && parsedInt <= hi);


### PR DESCRIPTION
Integer validation via regex is unfortunately very slow. For now, regex validation for floats will be kept, since custom validation would be very cumbersome, and problems with floats usually have high overhead regardless.